### PR TITLE
fix(serialization): Fix @serializable inheritance double-wrapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezserialization"
-version = "0.5.4"
+version = "0.6.0"
 description = "Simple, easy to use & transparent python objects serialization & deserialization."
 authors = [
     { name = "Matas Gumbinas", email = "matas.gumbinas@gmail.com" }

--- a/src/ezserialization/_serialization.py
+++ b/src/ezserialization/_serialization.py
@@ -149,15 +149,12 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                 @functools.wraps(method)
                 def to_dict_wrapper(__ctx, *__args, **__kwargs):
                     data = method(__ctx, *__args, **__kwargs)
-                    # Wrap object with serialization metadata.
-                    if type_field_name in data:
-                        raise KeyError(
-                            f"Key '{type_field_name}' already exist in the serialized data mapping! "
-                            f"Change ezserialization's {type_field_name=} to some other value to not conflict with "
-                            f"your existing codebase."
-                        )
                     if _get_serialization_enabled():
                         typename = _typenames_[__ctx if isinstance(__ctx, type) else type(__ctx)]
+                        if type_field_name in data:
+                            # Inner method already injected type info (inherited wrapper).
+                            # Replace with the correct typename for this instance's type.
+                            data = {k: v for k, v in data.items() if k != type_field_name}
                         # Add deserialization metadata.
                         return {type_field_name: typename, **data}
                     return data
@@ -171,8 +168,11 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                 def from_dict_wrapper(*__args, **__kwargs) -> Serializable:
                     # Differentiate between different ways this method was called.
                     first_arg_type = val if isinstance(val := __args[0], type) else type(val)
-                    if _is_same_type_by_qualname(first_arg_type, cls_):
+                    if _is_same_type_by_qualname(first_arg_type, cls_) or (
+                        isinstance(val, type) and issubclass(val, cls_)
+                    ):
                         # When this method was called as instance-method i.e. Serializable().from_dict(...)
+                        # or via an outer wrapper passing a subclass as the first argument.
                         __cls = first_arg_type
                         src = __args[1]
                         __args = __args[2:]
@@ -187,6 +187,9 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                     src.pop(type_field_name, None)
 
                     # Deserialize.
+                    if hasattr(method, "__func__"):
+                        # Bound classmethod: call underlying function with resolved class.
+                        return method.__func__(__cls, src, *__args, **__kwargs)
                     if hasattr(method, "__self__"):
                         # As bounded method (class or instance method)
                         return method(src, *__args, **__kwargs)

--- a/src/ezserialization/_serialization.py
+++ b/src/ezserialization/_serialization.py
@@ -175,8 +175,8 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                 def from_dict_wrapper(*__args, **__kwargs) -> Serializable:
                     # Differentiate between different ways this method was called.
                     first_arg_type = val if isinstance(val := __args[0], type) else type(val)
-                    if _is_same_type_by_qualname(first_arg_type, cls_) or (
-                        isinstance(val, type) and issubclass(val, cls_)
+                    if isinstance(val, type) and issubclass(val, cls_) or (
+                        _is_same_type_by_qualname(first_arg_type, cls_)
                     ):
                         # When this method was called as instance-method i.e. Serializable().from_dict(...)
                         # or via an outer wrapper passing a subclass as the first argument.

--- a/src/ezserialization/_serialization.py
+++ b/src/ezserialization/_serialization.py
@@ -198,7 +198,7 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                     # Deserialize.
                     if hasattr(method, "__func__"):
                         # Bound classmethod: call underlying function with resolved class.
-                        return method.__func__(__cls, src, *__args, **__kwargs)
+                        return cast(Serializable, method.__func__(__cls, src, *__args, **__kwargs))
                     if hasattr(method, "__self__"):
                         # As bounded method (class or instance method)
                         return method(src, *__args, **__kwargs)

--- a/src/ezserialization/_serialization.py
+++ b/src/ezserialization/_serialization.py
@@ -175,8 +175,10 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                 def from_dict_wrapper(*__args, **__kwargs) -> Serializable:
                     # Differentiate between different ways this method was called.
                     first_arg_type = val if isinstance(val := __args[0], type) else type(val)
-                    if isinstance(val, type) and issubclass(val, cls_) or (
-                        _is_same_type_by_qualname(first_arg_type, cls_)
+                    if (
+                        isinstance(val, type)
+                        and issubclass(val, cls_)
+                        or (_is_same_type_by_qualname(first_arg_type, cls_))
                     ):
                         # When this method was called as instance-method i.e. Serializable().from_dict(...)
                         # or via an outer wrapper passing a subclass as the first argument.

--- a/src/ezserialization/_serialization.py
+++ b/src/ezserialization/_serialization.py
@@ -149,12 +149,19 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
                 @functools.wraps(method)
                 def to_dict_wrapper(__ctx, *__args, **__kwargs):
                     data = method(__ctx, *__args, **__kwargs)
+                    if type_field_name in data:
+                        if data[type_field_name] not in _types_:
+                            # User's own data conflicts with the serialization key.
+                            raise KeyError(
+                                f"Key '{type_field_name}' already exist in the serialized data mapping! "
+                                f"Change ezserialization's {type_field_name=} to some other value to not "
+                                f"conflict with your existing codebase."
+                            )
+                        # Inner method already injected type info (inherited wrapper).
+                        # Strip it so we can re-add with the correct typename below.
+                        data = {k: v for k, v in data.items() if k != type_field_name}
                     if _get_serialization_enabled():
                         typename = _typenames_[__ctx if isinstance(__ctx, type) else type(__ctx)]
-                        if type_field_name in data:
-                            # Inner method already injected type info (inherited wrapper).
-                            # Replace with the correct typename for this instance's type.
-                            data = {k: v for k, v in data.items() if k != type_field_name}
                         # Add deserialization metadata.
                         return {type_field_name: typename, **data}
                     return data

--- a/src/ezserialization/_serialization.py
+++ b/src/ezserialization/_serialization.py
@@ -3,7 +3,7 @@ import functools
 import importlib
 import threading
 from abc import abstractmethod
-from typing import Callable, Dict, Iterator, Mapping, Optional, Protocol, Type, TypeVar, cast
+from typing import Callable, Dict, Iterator, Mapping, Optional, Protocol, Type, TypeVar, cast, overload
 
 __all__ = [
     "type_field_name",
@@ -221,7 +221,25 @@ def serializable(cls: Optional[Type[_T]] = None, *, name: Optional[str] = None):
     return wrapper(cls)
 
 
-def deserialize(src: Mapping) -> Serializable:
+@overload
+def deserialize(src: Mapping) -> Serializable: ...
+
+
+@overload
+def deserialize(src: Mapping, return_type: Type[_T]) -> _T: ...
+
+
+def deserialize(src: Mapping, return_type: Optional[Type[_T]] = None) -> Serializable:
+    """Deserialize a mapping into a Serializable object.
+
+    :param src: Source mapping containing serialized data with a type field.
+    :param return_type: Expected return type. If provided, the deserialized object
+        is validated to be an instance of this type.
+    :return: Deserialized object.
+    :raises KeyError: If the source mapping does not contain the type field.
+    :raises TypeError: If return_type is provided and the deserialized object
+        does not match.
+    """
     if not isdeserializable(src):
         raise KeyError(f"Given data mapping does not contain key '{type_field_name}' required for deserialization.")
 
@@ -245,4 +263,8 @@ def deserialize(src: Mapping) -> Serializable:
 
     cls = _types_[typename if typename_alias is None else typename_alias]
     obj = cls.from_dict(src)
+
+    if return_type is not None and not isinstance(obj, return_type):
+        raise TypeError(f"Expected {return_type.__name__}, got {type(obj).__name__}")
+
     return obj

--- a/tests/ezserialization_tests/test_serializable_decorator.py
+++ b/tests/ezserialization_tests/test_serializable_decorator.py
@@ -1,6 +1,8 @@
 import json
 from typing import Mapping, cast
 
+import pytest
+
 from ezserialization import (
     Serializable,
     deserialize,
@@ -104,3 +106,30 @@ def test_serialization_typenames_order():
     data = b.to_dict()
     assert data["_type_"] == "B"
     assert b.value == cast(_CaseBUsingNameAlias, deserialize(json.loads(json.dumps(data)))).value
+
+
+def test_deserialize_return_type():
+    parent = _SerializableParent("hello")
+    data = json.loads(json.dumps(parent.to_dict()))
+
+    # Correct return_type passes
+    restored = deserialize(data, return_type=_SerializableParent)
+    assert isinstance(restored, _SerializableParent)
+    assert restored.value == "hello"
+
+    # Child is a subclass of parent, so return_type=parent should pass
+    child = _SerializableChild("world")
+    data = json.loads(json.dumps(child.to_dict()))
+    restored = deserialize(data, return_type=_SerializableParent)
+    assert isinstance(restored, _SerializableChild)
+
+    # Exact child type
+    restored = deserialize(data, return_type=_SerializableChild)
+    assert isinstance(restored, _SerializableChild)
+
+    # Wrong type raises TypeError
+    with pytest.raises(TypeError, match=f"Expected {_SerializableChild.__name__}"):
+        deserialize(
+            json.loads(json.dumps(parent.to_dict())),
+            return_type=_SerializableChild,
+        )

--- a/tests/ezserialization_tests/test_serializable_decorator.py
+++ b/tests/ezserialization_tests/test_serializable_decorator.py
@@ -5,6 +5,7 @@ from ezserialization import (
     Serializable,
     deserialize,
     serializable,
+    type_field_name,
 )
 
 
@@ -44,6 +45,44 @@ class _CaseBUsingNameAlias(Serializable):
     @classmethod
     def from_dict(cls, src: Mapping):
         return cls(value=src["value"])
+
+
+@serializable
+class _SerializableParent:
+    def __init__(self, value: str):
+        self.value = value
+
+    def to_dict(self) -> Mapping:
+        return {"value": self.value}
+
+    @classmethod
+    def from_dict(cls, src: Mapping):
+        return cls(value=src["value"])
+
+
+@serializable
+class _SerializableChild(_SerializableParent):
+    """Inherits to_dict/from_dict from parent."""
+    pass
+
+
+def test_serializable_inheritance():
+    # Parent round-trip
+    parent = _SerializableParent("hello")
+    data = parent.to_dict()
+    assert data[type_field_name] == f"{_SerializableParent.__module__}.{_SerializableParent.__qualname__}"
+    restored = deserialize(json.loads(json.dumps(data)))
+    assert isinstance(restored, _SerializableParent)
+    assert not isinstance(restored, _SerializableChild)
+    assert restored.value == "hello"
+
+    # Child round-trip (inherits to_dict/from_dict)
+    child = _SerializableChild("world")
+    data = child.to_dict()
+    assert data[type_field_name] == f"{_SerializableChild.__module__}.{_SerializableChild.__qualname__}"
+    restored = deserialize(json.loads(json.dumps(data)))
+    assert isinstance(restored, _SerializableChild)
+    assert restored.value == "world"
 
 
 def test_serialization_typenames_order():

--- a/tests/ezserialization_tests/test_serializable_decorator.py
+++ b/tests/ezserialization_tests/test_serializable_decorator.py
@@ -63,6 +63,7 @@ class _SerializableParent:
 @serializable
 class _SerializableChild(_SerializableParent):
     """Inherits to_dict/from_dict from parent."""
+
     pass
 
 


### PR DESCRIPTION
## Summary

- Fix `to_dict` double-wrapping: detect inherited wrapper via `type_field_name` presence in output and overwrite with the correct child typename instead of raising `KeyError`
- Fix `from_dict` argument misparse: add `issubclass` check so inner wrappers correctly recognize subclass arguments passed by outer wrappers
- Fix classmethod dispatch: use `__func__` to call bound classmethods with the correctly resolved class, ensuring child instances are created (not parent)
- Add return_type parameter to deserialize

## Test plan

- [x] Added `test_serializable_inheritance` covering parent and child round-trip serialization/deserialization
- [x] Added `test_deserialize_return_type` covering parent and child round-trip serialization/deserialization
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)